### PR TITLE
Add modifications needed for GNU 11.3.1 to compile successfully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,13 @@ export OMPI_CC=$(SCC)
 ifeq ($(ESMF_COMPILER),intel)
 	export OMPI_CXX=icpc
 	TRACEBACK_OPT := -traceback
+	CHECK_BOUNDS_OPT := -check bounds
+	COMPILER_FLAGS := -DLINUX_IFORT
 else ifeq ($(ESMF_COMPILER),gfortran)
 	export OMPI_CXX=g++
 	TRACEBACK_OPT := -fbacktrace
+	CHECK_BOUNDS_OPT := -fcheck=bounds
+	COMPILER_FLAGS := -DLINUX_GFORTRAN
 endif
 
 # Specify MPI-specific options (hplin, 6/23/19)
@@ -301,7 +305,7 @@ compile_chem: test_registry_dummy
 	if   grep -q DESMF_ "$(ROOTDIR)/main/Makefile"; then cp $(ROOTDIR)/main/Makefile.bak $(ROOTDIR)/main/Makefile; fi
 	if   grep -q chem/gigc "$(ROOTDIR)/main/Makefile"; then cp $(ROOTDIR)/main/Makefile.bak $(ROOTDIR)/main/Makefile; fi
 	if   grep -q Isoropia "$(ROOTDIR)/main/Makefile"; then cp $(ROOTDIR)/main/Makefile.bak $(ROOTDIR)/main/Makefile; fi
-	if ! grep -q DMODEL_WRF "$(ROOTDIR)/main/Makefile"; then cp $(ROOTDIR)/main/Makefile $(ROOTDIR)/main/Makefile.bak; sed -i -e "s@-o wrf\.exe .*@& -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; sed -i -e "s@-o real\.exe .*@& -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; sed -i -e "s@-o nup\.exe .*@& -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; sed -i -e "s@-o ndown\.exe .*@& -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; sed -i -e "s@-o tc\.exe .*@& -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; fi
+	if ! grep -q DMODEL_WRF "$(ROOTDIR)/main/Makefile"; then cp $(ROOTDIR)/main/Makefile $(ROOTDIR)/main/Makefile.bak; sed -i -e "s@-o wrf\.exe .*@& $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; sed -i -e "s@-o real\.exe .*@& $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; sed -i -e "s@-o nup\.exe .*@& $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; sed -i -e "s@-o ndown\.exe .*@& $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; sed -i -e "s@-o tc\.exe .*@& $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -lGIGC $(MPI_OPT) -L$(ROOTDIR)/chem/gc/lib -lHistory -lGeosCore -lHistory -lKpp -lGeosCore -lIsorropia -lHCOI -lHCOX -lHCO -lGeosUtil -lKpp -lHeaders -lNcUtils -L$(NETCDFPATH) -lnetcdff -lnetcdf -L$(HDF5PATH)/lib -I$(ROOTDIR)/chem/gc/mod -lnetcdf@" "$(ROOTDIR)/main/Makefile"; fi
 
 	@echo "   *********** GEOS-CHEM HAS BEEN INSTALLED IN WRF ***********   "
 	@echo "   Please remember that:                                         "
@@ -432,7 +436,7 @@ wrfgc_history_mod.o: compile_chem
           $(WRF_SRC_ROOT_DIR)/var/build/da_name_space.pl $*.f90 > $*.f90.tmp ; \
           mv $*.f90.tmp $*.f90 ; \
         fi
-	$(FC) -o $@ -c $(FCFLAGS) -check bounds $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -L$(PNETCDF)/lib -I$(PNETCDF)/include -lpnetcdf -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
+	$(FC) -o $@ -c $(FCFLAGS) $(CHECK_BOUNDS_OPT) $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -L$(PNETCDF)/lib -I$(PNETCDF)/include -lpnetcdf -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
 
 wrfgc_io_pnetcdf.o: compile_chem wrfgc_history_mod.o
 	$(RM) $@
@@ -444,7 +448,7 @@ wrfgc_io_pnetcdf.o: compile_chem wrfgc_history_mod.o
           $(WRF_SRC_ROOT_DIR)/var/build/da_name_space.pl $*.f90 > $*.f90.tmp ; \
           mv $*.f90.tmp $*.f90 ; \
         fi
-	$(FC) -o $@ -c $(FCFLAGS) -check bounds $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -L$(PNETCDF)/lib -I$(PNETCDF)/include -lpnetcdf -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
+	$(FC) -o $@ -c $(FCFLAGS) $(CHECK_BOUNDS_OPT) $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -L$(PNETCDF)/lib -I$(PNETCDF)/include -lpnetcdf -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
 
 CONVERT_STATE_RELA = 	compile_chem \
 						module_input_chem_data.o \
@@ -475,7 +479,7 @@ wrfgc_convert_state_mod.o: $(CONVERT_STATE_RELA)
           $(WRF_SRC_ROOT_DIR)/var/build/da_name_space.pl $*.f90 > $*.f90.tmp ; \
           mv $*.f90.tmp $*.f90 ; \
         fi
-	$(FC) -o $@ -c $(FCFLAGS) -check bounds $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -L$(PNETCDF)/lib -I$(PNETCDF)/include -lpnetcdf -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
+	$(FC) -o $@ -c $(FCFLAGS) $(CHECK_BOUNDS_OPT) $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -L$(PNETCDF)/lib -I$(PNETCDF)/include -lpnetcdf -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
 
 chemics_init.o: $(CHEMICS_INIT_RELA)
 	$(RM) $@
@@ -489,7 +493,7 @@ chemics_init.o: $(CHEMICS_INIT_RELA)
           $(WRF_SRC_ROOT_DIR)/var/build/da_name_space.pl $*.f90 > $*.f90.tmp ; \
           mv $*.f90.tmp $*.f90 ; \
         fi
-	$(FC) -o $@ -c $(FCFLAGS) -check bounds $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
+	$(FC) -o $@ -c $(FCFLAGS) $(CHECK_BOUNDS_OPT) $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
 
 chem_driver.o: compile_chem ../dyn_em/module_convtrans_prep.o module_input_chem_data.o module_chem_utilities.o module_tropopause.o  module_upper_bc_driver.o wrfgc_convert_state_mod.o optical_driver.o module_diag_aero_size_info.o mixactivate_driver.o
 	$(RM) $@
@@ -503,6 +507,6 @@ chem_driver.o: compile_chem ../dyn_em/module_convtrans_prep.o module_input_chem_
           $(WRF_SRC_ROOT_DIR)/var/build/da_name_space.pl $*.f90 > $*.f90.tmp ; \
           mv $*.f90.tmp $*.f90 ; \
         fi
-	$(FC) -o $@ -c $(FCFLAGS) -check bounds $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) -DLINUX_IFORT -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
+	$(FC) -o $@ -c $(FCFLAGS) $(CHECK_BOUNDS_OPT) $(TRACEBACK_OPT) $(OMP) $(MODULE_DIRS) $(COMPILER_FLAGS) -DEXTERNAL_GRID -DNC_DIAG -DUCX -DGEOS_FP -DNC_HAS_COMPRESSION -DMODEL_ -DMODEL_WRF -DUSE_REAL8 -I$(ROOTDIR)/chem/gc/mod $(PROMOTION) $(FCSUFFIX) $*.f90
 
 # Note that linking is suppressed for chemics & chem_driver, so you have to do this linking in wrf.exe, ndown/nup.exe, ...

--- a/chem_driver.F
+++ b/chem_driver.F
@@ -684,16 +684,16 @@ subroutine chem_driver(grid, config_flags &
          ! It now accepts configuration in the WRF namelist for each individual process,
          ! so you can turn off turbulence if it causes spurious results
          ! (hplin, 8/15/18)
-         GIGC_Ops%Conv   = config_flags%gc_do_convection
-         GIGC_Ops%Emis   = config_flags%gc_do_hemco
-         GIGC_Ops%Tend   = .not. config_flags%gc_do_pblmix
-         GIGC_Ops%Turb   = config_flags%gc_do_pblmix
-         GIGC_Ops%Chem   = config_flags%gc_do_chemistry
-         GIGC_Ops%DryDep = config_flags%gc_do_drydep
-         GIGC_Ops%WetDep = config_flags%gc_do_wetdep
+         GIGC_Ops%Conv   = (config_flags%gc_do_convection .eq. 1)
+         GIGC_Ops%Emis   = (config_flags%gc_do_hemco .eq. 1)
+         GIGC_Ops%Tend   = .not. (config_flags%gc_do_pblmix .eq. 1)
+         GIGC_Ops%Turb   = (config_flags%gc_do_pblmix .eq. 1)
+         GIGC_Ops%Chem   = (config_flags%gc_do_chemistry .eq. 1)
+         GIGC_Ops%DryDep = (config_flags%gc_do_drydep .eq. 1)
+         GIGC_Ops%WetDep = (config_flags%gc_do_wetdep .eq. 1)
          GIGC_Ops%Rad    = .false.
 
-         GIGC_Ops%GCDiagn = config_flags%gc_do_gcdiagn
+         GIGC_Ops%GCDiagn = (config_flags%gc_do_gcdiagn .eq. 1)
       else
          GIGC_Ops%Conv   = .false.
          GIGC_Ops%Emis   = .false.

--- a/chemics_init.F
+++ b/chemics_init.F
@@ -260,7 +260,7 @@ subroutine chem_init(id, chem, emis_ant, scalar, dt, bioemdt, photdt, &
       ! Temporary kludge to tune down KPP sensitivity if operating in multi-domain
       ! mode. (hplin, 5/20/20)
       if(config_flags%gc_kpp_stop) then                       ! Default behavior
-        if(Global_Input_Opt%KppStop .eq. .true.) then
+        if(Global_Input_Opt%KppStop .eqv. .true.) then
           if(grid%id .ge. 2) then
             Global_Input_Opt%KppStop = .false.
           endif
@@ -270,7 +270,7 @@ subroutine chem_init(id, chem, emis_ant, scalar, dt, bioemdt, photdt, &
       endif
 
       ! Show a KPP warning for this...
-      if(Global_Input_Opt%KppStop .eq. .false.) then
+      if(Global_Input_Opt%KppStop .eqv. .false.) then
         write(6,*) "*** WRF-GC WARNING ***"
         write(6,*) "YOU ARE RUNNING WRF-GC IN MULTI-DOMAIN NESTED MODE, WHICH DISABLES"
         write(6,*) "CRITICAL INTEGRITY FAILSAFES WITHIN GEOS-CHEM KPP INTEGRATOR."
@@ -285,7 +285,7 @@ subroutine chem_init(id, chem, emis_ant, scalar, dt, bioemdt, photdt, &
       endif
 
       ! Have we ran this before...?
-      if(GIGC_States(grid%id)%Init .eq. .true.) then
+      if(GIGC_States(grid%id)%Init .eqv. .true.) then
         write(6, *) "WRFGC chemics_init: Domain", grid%id, "already initialized, skipping."
         return
       endif

--- a/config/couplers/wrfgc_convert_state_mod.F.ch4
+++ b/config/couplers/wrfgc_convert_state_mod.F.ch4
@@ -48,8 +48,7 @@ module WRFGC_Convert_State_Mod
 
     ! GEOS-Chem
     use GIGC_Chunk_Mod
-    use PRECISION_MOD
-    use Species_Mod,    only: MISSING_INT
+    use PRECISION_MOD ! MISSING_INT already imported here
     use ERROR_MOD,      only: IT_IS_NAN
     use Input_Opt_Mod,  only: OptInput
     use State_Chm_Mod,  only: ChmState, Ind_
@@ -1131,7 +1130,10 @@ contains
 #ifdef use_wrfgc_history_output
         !------------------WRF-GC diagnostics module------------------!
         call wrf_debug(100, "WRFGC_Convert_State_Mod IO pnetCDF: Start writing diagnostics")
-        call writeDiag(debug_level, Input_Opt, State_Met, State_Chm, grid, State_Grid, State_Diag, its, ite, jts, jte, ide, jde, kte)
+        call writeDiag(debug_level, Input_Opt, State_Met, State_Chm, grid, State_Grid, State_Diag, &
+                    int(its, MPI_OFFSET_KIND), int(ite, MPI_OFFSET_KIND), int(jts, MPI_OFFSET_KIND), &
+                    int(jte, MPI_OFFSET_KIND), int(ide, MPI_OFFSET_KIND), int(jde, MPI_OFFSET_KIND), &
+                    int(kte, MPI_OFFSET_KIND))
         call wrf_debug(100, "WRFGC_Convert_State_Mod IO pnetCDF: End writing diagnostics")
 #endif
 

--- a/config/couplers/wrfgc_convert_state_mod.F.co2
+++ b/config/couplers/wrfgc_convert_state_mod.F.co2
@@ -48,8 +48,7 @@ module WRFGC_Convert_State_Mod
 
     ! GEOS-Chem
     use GIGC_Chunk_Mod
-    use PRECISION_MOD
-    use Species_Mod,    only: MISSING_INT
+    use PRECISION_MOD ! MISSING_INT already imported here
     use ERROR_MOD,      only: IT_IS_NAN
     use Input_Opt_Mod,  only: OptInput
     use State_Chm_Mod,  only: ChmState, Ind_
@@ -1132,7 +1131,10 @@ contains
 #ifdef use_wrfgc_history_output
         !------------------WRF-GC diagnostics module------------------!
         call wrf_debug(100, "WRFGC_Convert_State_Mod IO pnetCDF: Start writing diagnostics")
-        call writeDiag(debug_level, Input_Opt, State_Met, State_Chm, grid, State_Grid, State_Diag, its, ite, jts, jte, ide, jde, kte)
+        call writeDiag(debug_level, Input_Opt, State_Met, State_Chm, grid, State_Grid, State_Diag, &
+                    int(its, MPI_OFFSET_KIND), int(ite, MPI_OFFSET_KIND), int(jts, MPI_OFFSET_KIND), &
+                    int(jte, MPI_OFFSET_KIND), int(ide, MPI_OFFSET_KIND), int(jde, MPI_OFFSET_KIND), &
+                    int(kte, MPI_OFFSET_KIND))
         call wrf_debug(100, "WRFGC_Convert_State_Mod IO pnetCDF: End writing diagnostics")
 #endif
 

--- a/config/couplers/wrfgc_convert_state_mod.F.fullchem
+++ b/config/couplers/wrfgc_convert_state_mod.F.fullchem
@@ -48,8 +48,7 @@ module WRFGC_Convert_State_Mod
 
     ! GEOS-Chem
     use GIGC_Chunk_Mod
-    use PRECISION_MOD
-    use Species_Mod,    only: MISSING_INT
+    use PRECISION_MOD ! MISSING_INT already imported here
     use ERROR_MOD,      only: IT_IS_NAN
     use Input_Opt_Mod,  only: OptInput
     use State_Chm_Mod,  only: ChmState, Ind_
@@ -2003,7 +2002,10 @@ contains
 #ifdef use_wrfgc_history_output
         !------------------WRF-GC diagnostics module------------------!
         call wrf_debug(100, "WRFGC_Convert_State_Mod IO pnetCDF: Start writing diagnostics")
-        call writeDiag(debug_level, Input_Opt, State_Met, State_Chm, grid, State_Grid, State_Diag, its, ite, jts, jte, ide, jde, kte)
+        call writeDiag(debug_level, Input_Opt, State_Met, State_Chm, grid, State_Grid, State_Diag, &
+                    int(its, MPI_OFFSET_KIND), int(ite, MPI_OFFSET_KIND), int(jts, MPI_OFFSET_KIND), &
+                    int(jte, MPI_OFFSET_KIND), int(ide, MPI_OFFSET_KIND), int(jde, MPI_OFFSET_KIND), &
+                    int(kte, MPI_OFFSET_KIND))
         call wrf_debug(100, "WRFGC_Convert_State_Mod IO pnetCDF: End writing diagnostics")
 #endif
 

--- a/module_diag_aero_size_info.F
+++ b/module_diag_aero_size_info.F
@@ -249,7 +249,7 @@
 	real, dimension(1:nbin_o) :: xmas_secti, xmas_sectj, xmas_sectc, xmas_sect_sna_oc, xmas_sect_bc, xmas_sect_sala, xmas_sect_salc
 	real, dimension(1:nbin_o) :: xdia_cm
 	real, parameter           :: FRAC2Aitken = 0.10 ! Fraction of modal mass in Aitken mode
-	real, parameter           :: ndust1 = 4         ! Number of dust bins of GEOS-Chem
+	integer, parameter           :: ndust1 = 4         ! Number of dust bins of GEOS-Chem
 	real                      :: dustfrc_gigc4bin(ndust1, nbin_o) ! GEOS-Chem dust size distribution - mass fracs in MOSAIC 4-bins
         real                      :: dgnum_um, dlo_um, dhi_um, duma, sixpi, dlo, dhi, dxbin, relh_frc, dgnum_sna_oc, dgnum_bc, sigma_sna_oc, sigma_bc, &
                                      dgnum_sala, dgnum_salc, sigma_sala, sigma_salc

--- a/module_optical_averaging.F
+++ b/module_optical_averaging.F
@@ -512,7 +512,7 @@
    real, dimension(1:nbin_o) :: xmas_secti, xmas_sectj, xmas_sectc, xmas_sect_sna_oc, xmas_sect_bc, xmas_sect_sala, xmas_sect_salc
    real, parameter :: pi = 3.141592653589
    real, parameter :: FRAC2Aitken = 0.25   ! Fraction of modal mass in Aitken mode - applied globally to each species
-   real, parameter :: ndust1 = 4         ! Number of dust bins of GEOS-Chem
+   integer, parameter :: ndust1 = 4         ! Number of dust bins of GEOS-Chem
    real  :: dustfrc_gigc4bin(ndust1, nbin_o) ! GEOS-Chem dust size distribution - mass fracs in MOSAIC 4-bins
    real  :: dgnum_um, dlo_um, dhi_um, duma, dxbin, relh_frc, dgnum_sna_oc, dgnum_bc, sigma_sna_oc, sigma_bc, &
             dgnum_sala, dgnum_salc, sigma_sala, sigma_salc

--- a/wrfgc_io_pnetcdf.F
+++ b/wrfgc_io_pnetcdf.F
@@ -1236,7 +1236,7 @@ contains
       call check(ierr, 'def dim lat')
       ierr = nf90mpi_def_dim(ncid, 'lev', kte, dimids(3))
       call check(ierr, 'def dim lev')
-      ierr = nf90mpi_def_dim(ncid, 'time', 0, dimids(4))
+      ierr = nf90mpi_def_dim(ncid, 'time', 0_MPI_OFFSET_KIND, dimids(4))
       call check(ierr, 'def dim lev')
       ierr = nf90mpi_def_dim(ncid, 'lon_e', ide, dimids(5))
       call check(ierr, 'def dim lon_e')
@@ -1244,7 +1244,7 @@ contains
       call check(ierr, 'def dim lat_e')
       ierr = nf90mpi_def_dim(ncid, 'ilev', kte+1, dimids(7))
       call check(ierr, 'def dim ilev')
-      ierr = nf90mpi_def_dim(ncid, 'nb', 2, dimids(8))
+      ierr = nf90mpi_def_dim(ncid, 'nb', 2_MPI_OFFSET_KIND, dimids(8))
 
       ierr = nf90mpi_def_var(ncid, 'lon', NF90_FLOAT, dimids(1), varid)
       call check(ierr, 'def var lon')


### PR DESCRIPTION
Those edits are needed for successful compilation over GCC 11.3.1 and OpenMPI 4.1.7 on WashU Compute2.